### PR TITLE
Improved padding of user name and logout button

### DIFF
--- a/fars/booking/static/css/base.css
+++ b/fars/booking/static/css/base.css
@@ -6,3 +6,11 @@
 #calendar {
 	height: calc(100vh - 80px);
 }
+
+#toolbar-user-name {
+  padding-right: .7rem;
+}
+
+#toolbar-btn {
+  vertical-align: inherit;
+}

--- a/fars/booking/templates/base.html
+++ b/fars/booking/templates/base.html
@@ -30,8 +30,8 @@
       {% endif %}
       {% if user.is_authenticated %}
         <span class="nav-item">
-          <span class="navbar-text">{{user.get_full_name}}</span>
-          <a class="btn btn-outline-danger" href="{% url 'logout' %}?next={{ request.build_absolute_uri }}">{% trans "Logout" %}</a>
+          <span class="navbar-text" id="toolbar-user-name">{{user.get_full_name}}</span>
+          <a class="btn btn-outline-danger" id="toolbar-btn" href="{% url 'logout' %}?next={{ request.build_absolute_uri }}">{% trans "Logout" %}</a>
         </span>
       {% else %}
         <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapseContent" aria-controls="collapseContent" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
- Increased horizontal padding right of the user's real name in the toolbar
- `vertical-align: middle` on the button did not work properly in the toolbar. Replacing its value with `inherit`