### PR TITLE
Make keyboardshortcuts disabled when modal is open

### DIFF
--- a/fars/booking/static/js/day.js
+++ b/fars/booking/static/js/day.js
@@ -138,17 +138,19 @@ $(document).ready(function() {
   function handleKeyboardEvent(evt) {
     if (!evt) {evt = window.event;} // for old IE compatible
     var keycode = evt.keyCode || evt.which; // also for cross-browser compatible
-    switch (keycode) {
-      case Key.LEFT:
-        calendar.fullCalendar('prev');
-        break;
-      case Key.RIGHT:
-        calendar.fullCalendar('next');
-        break;
-      case Key.M:
-        bookable = calendar.data('bookable')
-        window.location.href = '/booking/' + bookable;
-        break;
+    if (!$('#modalBox').hasClass('show')) {
+      switch (keycode) {
+        case Key.LEFT:
+          calendar.fullCalendar('prev');
+          break;
+        case Key.RIGHT:
+          calendar.fullCalendar('next');
+          break;
+        case Key.M:
+          bookable = calendar.data('bookable')
+          window.location.href = '/booking/' + bookable;
+          break;
+      }
     }
   }
 


### PR DESCRIPTION
Fix bug where keyboardshortcuts worked when booking. This made it impossible e.g. to book with a comment containing an "M"