### PR TITLE
Fix booking API auth

### DIFF
--- a/fars/api/tests.py
+++ b/fars/api/tests.py
@@ -1,3 +1,16 @@
-from django.test import TestCase
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
 
-# Create your tests here.
+
+class BookingApiTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='svakar', password='teknolog')
+
+    def test_bookings_list_requires_authentication(self):
+        response = self.client.get('/api/bookings')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        self.client.login(username='svakar', password='teknolog')
+        response = self.client.get('/api/bookings')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/fars/api/views.py
+++ b/fars/api/views.py
@@ -1,4 +1,5 @@
 from rest_framework import viewsets, generics
+from rest_framework.permissions import IsAuthenticated
 from django_filters import rest_framework as filters
 from booking.models import *
 from api.serializers import *
@@ -17,6 +18,7 @@ class BookingFilter(filters.FilterSet):
 
 
 class BookingsList(viewsets.ViewSetMixin, generics.ListAPIView):
+    permission_classes = [IsAuthenticated]
     queryset = Booking.objects.all()
     serializer_class = NoMetaBookingSerializer # Exclude metadata to hide doorcode in this API
     filter_backends = (filters.DjangoFilterBackend,)


### PR DESCRIPTION
- Ensure user is logged in before allowing `GET /api/bookings`
- Add testcase

Testing:
```
python fars/manage.py test fars/
```