### PR TITLE
Adds today, previous day and next day buttons to the day view

### DIFF
--- a/fars/booking/static/css/calendar-theme.css
+++ b/fars/booking/static/css/calendar-theme.css
@@ -389,3 +389,41 @@ table.fc-border-separate {
 
 .fc-event-vert .ui-resizable-s {
   bottom: 0 !important; }
+
+.fc-toolbar .btn {
+  border-style: solid;
+  border-color: #cccccc #bbbbbb #aaaaaa;
+  background: #f3f3f3;
+  color: black;
+}
+
+.fc-toolbar .btn:hover {
+  border-color: #999999; }
+  .fc-toolbar .btn:hover .fc-button-inner {
+    border-color: #999999; }
+
+.fc-toolbar .btn:down {
+  border-color: #555555;
+  background: #777777; }
+  .fc-toolbar .btn:down .fc-button-inner {
+    border-color: #555555;
+    background: #777777; }
+
+.fc-toolbar .btn:active {
+  border-color: #555555;
+  background: #777777;
+  color: white; }
+  .fc-toolbar .btn:active .fc-button-inner {
+    border-color: #555555;
+    background: #777777;
+    color: white; }
+
+.fc-toolbar .btn:disabled {
+  color: #999999;
+  border-color: #dddddd;
+  cursor: default;
+}
+
+.fc-toolbar h2 {
+  line-height: 1.5;
+}

--- a/fars/booking/static/js/day.js
+++ b/fars/booking/static/js/day.js
@@ -28,8 +28,8 @@ $(document).ready(function() {
       aspectRatio: 2,
       // header
       header: {
-        left: '',
-        center: 'title',
+        left: 'today prev,next title',
+        center: '',
         right: ''
       },
       views: {


### PR DESCRIPTION
PR adding enhancement according to #51.

The day view buttons are ordered in the same pattern as in the month view. Line-height changed to 1.5 so that the h2 title is centered vertically on mobile also (the div's line-height is also 1.5).

Also, pls add the `hacktoberfest-accepted` label to this PR :D